### PR TITLE
Units directly accessible from the top level

### DIFF
--- a/hepunits/__init__.py
+++ b/hepunits/__init__.py
@@ -5,5 +5,6 @@ from __future__ import absolute_import
 # Convenient access to the version number
 from .version import __version__
 
-# Units directly available
+# Units and constants directly available
 from .units import *
+from .constants import *

--- a/hepunits/__init__.py
+++ b/hepunits/__init__.py
@@ -4,3 +4,6 @@ from __future__ import absolute_import
 
 # Convenient access to the version number
 from .version import __version__
+
+# Units directly available
+from .units import *


### PR DESCRIPTION
This is the most common use for the package:

```
from hepunits.units import MeV
# becomes
from hepunits import MeV
```

Should constants be made available at the top level, too?