### PR TITLE
Fixes to setup

### DIFF
--- a/hepunits/version.py
+++ b/hepunits/version.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 version = __version__
 version_info = __version__.split('.')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,15 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-import os.path
+import sys
+import os
 
 from setuptools import setup
 from setuptools import find_packages
 
+# Only add pytest-runner if the setup.py call needs it
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 def get_version():
     g = {}
@@ -28,7 +32,7 @@ setup(
     license = 'new BSD',
     packages = find_packages(),
     include_package_data = True,
-    setup_requires = ['pytest-runner'],
+    setup_requires = [] + pytest_runner,
     tests_require = ['pytest'],
     keywords = [
         'HEP', 'units', 'constants',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,0 @@
-# Licensed under a 3-clause BSD style license, see LICENSE.

--- a/tests/constants/__init__.py
+++ b/tests/constants/__init__.py
@@ -1,1 +1,0 @@
-# Licensed under a 3-clause BSD style license, see LICENSE.

--- a/tests/units/__init__.py
+++ b/tests/units/__init__.py
@@ -1,1 +1,0 @@
-# Licensed under a 3-clause BSD style license, see LICENSE.


### PR DESCRIPTION
Addresses #2 (after tag and push, anyway.

* Always build universal wheels
* Make pytest-runner only a requirement for testing
* Make "test" call pytest
* Make tests not a package so find_package does not pick it up (we do not own the package name "tests" on PyPI)
* Bump version