### PR TITLE
fix: error instead of getting the wrong version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: pre-commit/action@v2.0.0
 
   checks:
     runs-on: ubuntu-latest
@@ -33,6 +27,7 @@ jobs:
         - 3.5
         - 3.6
         - 3.8
+
     name: Check Python ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check manifest
       uses: pre-commit/action@v2.0.0
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,12 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Check manifest
+      uses: pre-commit/action@v2.0.0
+      with:
+        extra_args: --hook-stage manual check-manifest
 
   checks:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,15 @@ repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v3.2.0
   hooks:
-  - id: check-added-large-files
+  - id: debug-statements
+  - id: end-of-file-fixer
+  - id: fix-encoding-pragma
   - id: mixed-line-ending
+  - id: requirements-txt-fixer
   - id: trailing-whitespace
-  - id: check-merge-conflict
+  - id: check-added-large-files
   - id: check-case-conflict
+  - id: check-merge-conflict
   - id: check-symlinks
   - id: check-yaml
 
@@ -21,6 +25,14 @@ repos:
   hooks:
   - id: check-manifest
     additional_dependencies: [setuptools_scm, toml]
+    stages: [manual]
+
+- repo: https://github.com/pycqa/flake8
+  rev: 3.8.3
+  hooks:
+  - id: flake8
+    exclude: docs/conf.py
+    additional_dependencies: [flake8-bugbear, flake8-print]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.782

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,9 @@ repos:
   rev: 19.10b0
   hooks:
   - id: black
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v3.2.0
   hooks:
   - id: check-added-large-files
   - id: mixed-line-ending
@@ -14,12 +15,15 @@ repos:
   - id: check-case-conflict
   - id: check-symlinks
   - id: check-yaml
+
 - repo: https://github.com/mgedmin/check-manifest
-  rev: "0.39"
+  rev: "0.42"
   hooks:
   - id: check-manifest
+    additional_dependencies: [setuptools_scm, toml]
+
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.770
+  rev: v0.782
   hooks:
   - id: mypy
     args: [--strict]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,4 +34,3 @@ jobs:
   - script: |
       python -m pytest tests/ --cov hepunits --cov-report html --napoleon-docstrings
     displayName: 'pytest'
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,5 +72,12 @@ ignore =
 
 [mypy]
 strict=True
+
 [mypy-hepunits.version]
 ignore_missing_imports = True
+
+
+[flake8]
+max-complexity = 12
+ignore = E203, E231, E501, E722, W503, F401, F403, F405
+select = C,E,F,W,B,B9,T

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
 from setuptools import setup
 
 # Setup will not be able to find the version if these packages are missing
-# (Remember, setup.py does not run when installing from a wheel, so only required to make one)
+#
+# > Remember, setup.py does not run when installing from a wheel, so only
+# > required to make one
 
 import setuptools_scm  # noqa: F401
 import toml  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,10 @@
 
 from setuptools import setup
 
+# Setup will not be able to find the version if these packages are missing
+# (Remember, setup.py does not run when installing from a wheel, so only required to make one)
+
+import setuptools_scm  # noqa: F401
+import toml  # noqa: F401
+
 setup()

--- a/src/hepunits/__init__.py
+++ b/src/hepunits/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
 # Convenient access to the version number

--- a/src/hepunits/constants/__init__.py
+++ b/src/hepunits/constants/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 This module `hepunits.constants` contains 2 sorts of constants:

--- a/src/hepunits/constants/constants.py
+++ b/src/hepunits/constants/constants.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 Physical and other handy constants

--- a/src/hepunits/units/__init__.py
+++ b/src/hepunits/units/__init__.py
@@ -1,9 +1,12 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
-"""
-Subpackage for the HEP System of Units, (derived) physical units
-and commonly-used unit prefixes.
 
-The HEP System of Units is the set of basic units originally defined by the CLHEP project.
+"""
+Subpackage for the HEP System of Units, (derived) physical units and
+commonly-used unit prefixes.
+
+The HEP System of Units is the set of basic units originally defined by the
+CLHEP project.
 """
 
 from .prefixes import *

--- a/src/hepunits/units/prefixes.py
+++ b/src/hepunits/units/prefixes.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 ********************

--- a/src/hepunits/units/units.py
+++ b/src/hepunits/units/units.py
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
+
 """
 *************************
 Module of HEP basic units
 *************************
 
-In HEP the System of Units consists of the basic units originally defined by the [CLHEP]_ project:
+In HEP the System of Units consists of the basic units originally defined by
+the [CLHEP]_ project:
 
     ===================   ================== ====
     Quantity              Name               Unit
@@ -34,7 +37,8 @@ It is largely based on the international system of units ([SI]_)
     Luminous intensity    candela    cd
     ===================   ========   ====
 
-but augments it with handy definitions, changing the basic length and time units.
+but augments it with handy definitions, changing the basic length and time
+units.
 
 This module also defines an extensive set of derived units.
 

--- a/tests/constants/test_constants.py
+++ b/tests/constants/test_constants.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 Tests for the hepunits.constants.constants module.

--- a/tests/units/test_prefixes.py
+++ b/tests/units/test_prefixes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 Tests for the hepunits.units.prefixes module.

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 """
 Tests for the hepunits.units.units module.


### PR DESCRIPTION
These packages may be missing when running setup.py directly instead of through pip or pep517.build.

Would have made #19 easier to diagnose.

Also adding more pre-commit checks, and some updates.