### PR TITLE
docs: Add CITATION.cff Citation File Format file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+title: hepunits
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+abstract: "Hepunits is a Python library for units and constants in the HEP system of units."
+authors:
+  - family-names: Rodrigues
+    given-names: Eduardo
+    affiliation: University of Liverpool
+    orcid: "https://orcid.org/0000-0003-2846-7625"
+doi: 10.5281/zenodo.7244906
+repository-code: "https://github.com/scikit-hep/hepunits"
+keywords:
+  - python
+  - HEP units
+  - scikit-hep
+license: "BSD-3-Clause"


### PR DESCRIPTION
Closes https://github.com/scikit-hep/hepunits/issues/86.

Add Citation File Format file to repo to get repository cite button on GitHub and citation support on Zenodo.
   - c.f. https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-citation-files

The schema used is validated by [`cffconvert`](https://pypi.org/project/cffconvert/)

```console
$ pipx install cffconvert
$ cffconvert --validate --infile CITATION.cff 
Citation metadata are valid according to schema version 1.2.0.
```