### PR TITLE
ci: update to Python 3.11 final

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11-dev"
+          - "3.11"
 
     name: Check Python ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos