### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ ignore = [
     "PT013",  # Okay to import approx from pytest
     "PLR",    # Design related pylint codes
 ]
-target-version = "py37"
 src = ["src"]
 
 [tool.ruff.per-file-ignores]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos