### PR TITLE
chore: remove invalid license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "hepunits"
 description = "Units and constants in the HEP system of units"
 readme = "README.rst"
-license = "BSD-3-Clause"
 requires-python = ">=3.7"
 authors = [
     { name = "Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch" },


### PR DESCRIPTION
This is invalid according to PEP 621 (which causes validate-pyproject to fail, from repo-review). There's no need for it anyway, as the Trove classifiers are sufficient.

Repo-review output:

<h2>General</h2>
<ul>
<li>Detected build backend: <code>hatchling.build</code></li>
<li>Detected license(s): BSD License</li>
</ul>

<table>
<tr><th>?</th><th><div style="min-width:5em;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>PY004</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/packaging-simple#PY004">Has docs folder</a>
<br/>
<p>Projects must have documentation in a folder called docs (disable if not applicable)</p>

</td>
</tr>
</table>
<h2>GitHub Actions</h2>
<table>
<tr><th>?</th><th><div style="min-width:5em;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>GH102</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/gha-basic#GH102">Auto-cancel on repeated PRs</a>
<br/>
<p>At least one workflow should auto-cancel.</p>
<pre><code class="language-yaml">concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
</code></pre>

</td>
</tr>
</table>
<h2>Pre-commit</h2>
<table>
<tr><th>?</th><th><div style="min-width:5em;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>PC111</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#PC111">Uses blacken-docs</a>
<br/>
<p>Use <code>https://github.com/adamchainz/blacken-docs</code> instead of <code>https://github.com/asottile/blacken-docs</code> in <code>.pre-commit-config.yaml</code></p>

</td>
</tr>
</table>
<h2>MyPy</h2>
<table>
<tr><th>?</th><th><div style="min-width:80px;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>MY102</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY102">MyPy show error codes</a>
<br/>
<p>Must have <code>show_error_codes = true</code>. This will print helpful error codes
for users that clarify why something fails if you need to skip it.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>MY103</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY103">MyPy warn unreachable</a>
<br/>
<p>Must have <code>warn_unreachable = true</code> to pass this check. There are
occasionally false positives (often due to platform or Python version
static checks), so it's okay to ignore this check. But try it first - it
can catch real bugs too.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>MY104</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY104">MyPy enables ignore-without-code</a>
<br/>
<p>Must have <code>&quot;ignore-without-code&quot;</code> in <code>enable_error_code = [...]</code>. This
will force all skips in your project to include the error code, which
makes them more readable, and avoids skipping something unintended.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>MY105</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY105">MyPy enables redundant-expr</a>
<br/>
<p>Must have <code>&quot;redundant-expr&quot;</code> in <code>enable_error_code = [...]</code>. This helps
catch useless lines of code, like checking the same condition twice.</p>

</td>
</tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>MY106</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/style#MY106">MyPy enables truthy-bool</a>
<br/>
<p>Must have <code>&quot;truthy-bool&quot;</code> in <code>enable_error_code = []</code>. This catches
mistakes in using a value as truthy if it cannot be falsey.</p>

</td>
</tr>
</table>
<h2>Documentation</h2>
<table>
<tr><th>?</th><th><div style="min-width:5em;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>RTD100</td>
<td>
<a href="https://learn.scientific-python.org/development/guides/docs#RTD100">Uses ReadTheDocs (pyproject config)</a>
<br/>
<p>Should have a .readthedocs.yaml file in the root of the repository.
Modern ReadTheDocs requires (or will require soon) this file.</p>

</td>
</tr>
</table>
<h2>Validate-PyProject</h2>
<p>Checks <code>[build-system]</code>, <code>[project]</code>, <code>[tool.repo-review]</code>, <code>[tool.setuptools]</code></p>

<table>
<tr><th>?</th><th><div style="min-width:5em;">Name</div></th><th>Description</th></tr>
<tr style="color: red;">
<td><span role="img" aria-label="Failed">❌</span></td>
<td>VPP001</td>
<td>
Validate pyproject.toml
<br/>
<p>Invalid pyproject.toml! Error: <code>project.license</code> must be valid exactly by one definition (2 matches found):</p>
<pre><code>- keys:
    'file': {type: string}
  required: ['file']
- keys:
    'text': {type: string}
  required: ['text']
</code></pre>

</td>
</tr>
</table>

