### PR TITLE
chore: use ruff-format & modernize config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,16 +17,12 @@ repos:
       - id: check-symlinks
       - id: check-yaml
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0
-    hooks:
-      - id: black-jupyter
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.1.5"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.0
@@ -51,7 +47,7 @@ repos:
     hooks:
       - id: blacken-docs
         args: ["-E"]
-        additional_dependencies: [black==22.8.0]
+        additional_dependencies: [black~=23.11]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 |Scikit-HEP| |PyPI version| |Conda-forge version| |Zenodo DOI|
 
-|GitHub Actions Status: CI| |Code Coverage| |Code style: black|
+|GitHub Actions Status: CI| |Code Coverage|
 
 
 ``hepunits`` collects the most commonly used units and constants in the
@@ -155,6 +155,3 @@ to ensure an explicit conversion to the desired unit dividing by it (GeV in the 
 
 .. |Code Coverage| image:: https://codecov.io/gh/scikit-hep/hepunits/graph/badge.svg?branch=master
    :target: https://codecov.io/gh/scikit-hep/hepunits?branch=master
-
-.. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/psf/black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,14 +88,16 @@ warn_unused_configs = true
 python_version = "3.7"
 files = ["src"]
 strict = true
-show_error_codes = true
 warn_unreachable = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 
+
 [tool.ruff]
-select = [
-    "E", "F", "W", # flake8
-    "B", "B904",   # flake8-bugbear
+src = ["src"]
+
+[tool.ruff.lint]
+extend-select = [
+    "B",           # flake8-bugbear
     "I",           # isort
     "ARG",         # flake8-unused-arguments
     "C4",          # flake8-comprehensions
@@ -114,21 +116,18 @@ select = [
     "UP",          # pyupgrade
     "YTT",         # flake8-2020
 ]
-ignore = [
-    "PT013",  # Okay to import approx from pytest
-    "PLR",    # Design related pylint codes
-]
-src = ["src"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "T20",
-    "F405",
     "F403",
+    "F405",
+    "PLR2004", # Magic value in comparisons
+    "PT013",   # Okay to import approx from pytest
+    "T20",
 ]
 
 [tool.repo-review]
 ignore = [
-    "RTD",     # ReadTheDocs
-    "PY0004",  # Has docs folder
+    "RTD",    # ReadTheDocs
+    "PY004",  # Has docs folder
 ]


### PR DESCRIPTION
Using ruff-format (30x faster than Black, mostly Black compatible, and already available in the hooks), modernizing some config options.
