### PR TITLE
chore: drop 3.7 and add 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     name: Check Python ${{ matrix.python-version }}
     steps:

--- a/README.rst
+++ b/README.rst
@@ -81,20 +81,20 @@ physical constants and commonly used constants.
 
 The typical usage is the following:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from hepunits.constants import c_light
-    >>> from hepunits.units     import picosecond, micrometer
-    >>> tau_Bs = 1.5 * picosecond    # a particle lifetime, say the Bs meson's
-    >>> ctau_Bs = c_light * tau_Bs   # ctau of the particle, ~450 microns
-    >>> print ctau_Bs                # result in HEP units, so mm
+    >>> from hepunits.units import picosecond, micrometer
+    >>> tau_Bs = 1.5 * picosecond  # a particle lifetime, say the Bs meson's
+    >>> ctau_Bs = c_light * tau_Bs  # ctau of the particle, ~450 microns
+    >>> print(ctau_Bs)  # result in HEP units, so mm
     0.449688687
-    >>> print ctau_Bs / micrometer   # result in micrometers
+    >>> print(ctau_Bs / micrometer)  # result in micrometers
     449.688687
 
 Typical usage of the ``hepunits.units`` module:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> # add two quantities with length units and get the result in meters
     >>> from hepunits import units as u
@@ -125,15 +125,15 @@ the function below stores a dimensioned quantity defined in keV
 (the actual value is represented in MeV, which is the standard unit) and the caller simply needs
 to ensure an explicit conversion to the desired unit dividing by it (GeV in the example):
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from hepunits.units import keV, MeV, GeV
-    >>> mass_window = 1 * GeV    # define a 1 GeV mass window
+    >>> mass_window = 1 * GeV  # define a 1 GeV mass window
     >>> def energy_resolution():
-    ...    # returns the energy resolution of 500 keV
-    ...    return 500. * keV  # numerical value is 0.5
+    ...     # returns the energy resolution of 500 keV
+    ...     return 500.0 * keV  # numerical value is 0.5
     ...
-    >>> energy_resolution() / GeV # get the energy resolution in GeV
+    >>> energy_resolution() / GeV  # get the energy resolution in GeV
     0.0005
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ def lint(session: nox.Session) -> None:
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session
 def tests(session: nox.Session) -> None:
     """
     Run the unit and regular tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "hepunits"
 description = "Units and constants in the HEP system of units"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Eduardo Rodrigues", email = "eduardo.rodrigues@cern.ch" },
 ]
@@ -28,11 +28,11 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering",
 ]
 dynamic = ["version"]
@@ -85,7 +85,7 @@ ignore = [
 
 [tool.mypy]
 warn_unused_configs = true
-python_version = "3.7"
+python_version = "3.8"
 files = ["src"]
 strict = true
 warn_unreachable = true
@@ -115,6 +115,9 @@ extend-select = [
     "T20",         # flake8-print
     "UP",          # pyupgrade
     "YTT",         # flake8-2020
+]
+ignore = [
+  "ISC001",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_missing_all.py
+++ b/tests/test_missing_all.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 import hepunits
@@ -15,9 +13,6 @@ def filter_module(item: str) -> bool:
     return True
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="Python 3.7+ added __dir__ support"
-)
 @pytest.mark.parametrize(
     "module",
     [


### PR DESCRIPTION
Fixed some warnings when running pre-commit with `-v` too.
