### PR TITLE
Get Codecov to upload again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,3 +52,5 @@ jobs:
 
       - name: Test coverage with Codecov
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The Codecov token was missing as a secret. Added now.