### PR TITLE
fix: Use the correct unit registry in pint

### DIFF
--- a/src/hepunits/pint.py
+++ b/src/hepunits/pint.py
@@ -65,7 +65,7 @@ def to_clhep(val: pint.Quantity | pint.Unit) -> float:
     9.800000000000001e-15
     """
     clhep_unit = _unit_from(val)
-    q = pint.Quantity(1.0, val) if isinstance(val, pint.Unit) else val
+    q = (1.0 * val) if isinstance(val, pint.Unit) else val
     return q.to(clhep_unit).magnitude  # type: ignore[no-any-return]
 
 
@@ -92,4 +92,4 @@ def from_clhep(val: float, unit: pint.Unit) -> pint.Quantity:
     <Quantity(299792458.0, 'meter / second')>
     """
     clhep_unit = _unit_from(unit)
-    return pint.Quantity(val, clhep_unit).to(unit)
+    return (val * clhep_unit).to(unit)

--- a/tests/test_pint.py
+++ b/tests/test_pint.py
@@ -45,3 +45,12 @@ def test_unsupported_dimension():
     ureg = pint.UnitRegistry()
     with pytest.raises(ValueError, match="Unsupported dimension"):
         to_clhep(1 * ureg.kelvin)
+
+
+def test_consistent_registry():
+    ureg = pint.UnitRegistry()
+
+    a = 1 * hepunits.mm
+    b = 3 * ureg.nanosecond
+    assert a * to_clhep(b) == 3 * hepunits.mm * hepunits.nanosecond
+    assert from_clhep(a, ureg.mm) * b == 3 * ureg.mm * ureg.nanosecond


### PR DESCRIPTION
As it turns out, using `pint.Quantity(val, unit)` uses a different registry than `val * unit` when we want to use the registry of `unit`